### PR TITLE
ecs: Fix missing of `awslogs-region` config for ECS task definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,12 +4,15 @@ locals {
   log_configuration = {
     logDriver = "awslogs"
     options = {
+      awslogs-region        = data.aws_region.current.name
       awslogs-group         = var.task_name
       awslogs-create-group  = "true"
       awslogs-stream-prefix = var.task_name
     }
   }
 }
+
+data "aws_region" "current" {}
 
 resource "aws_ecs_task_definition" "task" {
   family                   = var.task_name


### PR DESCRIPTION
When running a Fargate deployment, we need to specify the region of the
AWS CloudWatch Logs, which needs to be added as part of the
definition.LogConfiguration attribute.

We could add a new variable to tell us which AWS region to deploy the
changes. However, the current module, deploys all its resource on the
default AWS region from the user environment. Thus, let's use a
datasource to get the current default region. This will ensure the
configuration is comply with all the other resource creation.

Fixes #2
